### PR TITLE
Create python data structures notebook

### DIFF
--- a/Python Essentials/Data Structures in Python.ipynb
+++ b/Python Essentials/Data Structures in Python.ipynb
@@ -1,0 +1,149 @@
+# Data Structures in Python
+
+- This notebook covers Python's core data structures.
+- Follow the instructions in each cell. For this workshop, content is comments-only; write code beneath each section as needed.
+- Topics: Lists, Tuples, Sets, Dictionaries, Indexing & Slicing, Comprehensions, Common Patterns, Mutability & Copying, Iteration Helpers, Performance.
+
+---
+
+## Lists: ordered, mutable sequences
+- Create lists with `[]` or `list()`
+- Common operations: `append`, `extend`, `insert`, `remove`, `pop`, `clear`, `index`, `count`, `sort`, `reverse`
+- Access via indexing and slicing
+
+Task:
+- Create a list of 5 numbers
+- Print: length, first and last item
+- Append a new number, remove one
+- Sort the list and print
+
+---
+
+## Lists: common methods practice
+Task:
+- Start from a list of strings
+- Demonstrate: `extend` with another list, `insert` at index, `remove` by value, `pop` the last item
+- Reverse the list
+- Count occurrences of a specific value
+
+---
+
+## Tuples: ordered, immutable sequences
+- Create tuples with `()` or `tuple()`
+- Useful for fixed collections and returning multiple values
+- Support indexing and slicing; cannot be modified in place
+
+Task:
+- Create a tuple with 4 elements
+- Show indexing and slicing
+- In a comment, attempt to change an element and explain the error
+
+---
+
+## Tuple unpacking
+- Assign multiple variables at once
+- Use `_` to ignore values, and `*rest` to capture remaining values
+
+Task:
+- Unpack a 3-item tuple into variables
+- Use extended unpacking to capture remaining items from a longer tuple
+
+---
+
+## Sets: unordered collections of unique items
+- Create with `{}` or `set()`
+- Common operations: `add`, `update`, `remove`, `discard`, `pop`, `clear`
+- Set algebra: union (`|`), intersection (`&`), difference (`-`), symmetric difference (`^`)
+
+Task:
+- Given two sets, demonstrate each algebra operation
+- Show membership tests with `in`
+
+---
+
+## Dictionaries: key-value mappings
+- Create with `{key: value}` or `dict()`
+- Common operations: access, assign, `get`, `update`, `pop`, `keys`, `values`, `items`
+- Nesting and dictionary comprehension
+
+Task:
+- Create a dictionary for a student record (name, id, grades)
+- Read, update, and add a new field
+- Iterate over `items()` and print friendly messages
+
+---
+
+## Indexing and slicing
+- Indexing works on sequences (lists, tuples, strings)
+- Slicing syntax: `seq[start:stop:step]`; supports negatives
+
+Task:
+- Given a list of numbers 0..9, show: first 3, last 3, every second element, reversed list
+- Do the same with a string (e.g., `'datastructures'`)
+
+---
+
+## Comprehensions: list, set, dict
+- List comprehension: `[expr for x in iterable if cond]`
+- Set comprehension: `{expr for x in iterable}`
+- Dict comprehension: `{k_expr: v_expr for x in iterable}`
+
+Task:
+- Build: squares 0..10 (list), unique vowels from a string (set)
+- Map: word -> length for words in a sentence (dict)
+
+---
+
+## Common patterns: stacks, queues, heaps
+- Stack (LIFO): use list with `append`/`pop`
+- Queue (FIFO): use `collections.deque`
+- Priority queue: use `heapq` (min-heap)
+
+Task:
+- Implement a small stack and perform push/pop
+- Implement a queue with enqueue/dequeue
+- Use `heapq` to get 3 smallest numbers from a list
+
+---
+
+## Mutability and copying
+- Mutable: list, dict, set; Immutable: tuple, str, int, float
+- Copying: `copy()`/`list(x)`/`dict(x)` (shallow) vs `copy.deepcopy` (deep)
+- Pitfall: nested structures share inner references under shallow copy
+
+Task:
+- Create a nested list; make a shallow copy and modify inner list; observe both change
+- Use `deepcopy` and show the difference
+
+---
+
+## Iteration helpers
+- `enumerate(iterable, start=0)` to get index and value
+- `zip(a, b, ...)` to combine iterables
+- For dicts: iterate `keys()`, `values()`, `items()`
+
+Task:
+- Given two lists of equal length, print paired elements with their index using `enumerate` and `zip`
+- Iterate a dict with `items()` and print key/value
+
+---
+
+## Performance notes (Big-O cheatsheet)
+- List index access: O(1), insert/delete at end: O(1) amortized, at front: O(n)
+- Set/dict membership: average O(1); worst-case O(n) with poor hashing
+- Heap push/pop: O(log n)
+
+Task:
+- Briefly explain why list insert at index 0 is slower than append
+- For a membership-heavy workload, choose between list and set and justify
+
+---
+
+## Summary and practice
+- You explored lists, tuples, sets, dicts, slicing, comprehensions, patterns, mutability, helpers, and performance.
+
+Exercises:
+1) Build a frequency dictionary for words in a sentence (case-insensitive). Sort by frequency desc.
+2) Given a list with duplicates, produce a sorted list of unique items and a dict mapping each item to its count.
+3) From a list of (name, score) tuples, build a dict `name -> highest_score`, then list the top 3 by score.
+4) Given nested student records, deep copy them and safely modify one student's nested grades without affecting the original.


### PR DESCRIPTION
Add `Python Essentials/Data Structures in Python.ipynb` to cover Python data structures in a comment-only format, mirroring the first workshop notebook.

---
<a href="https://cursor.com/background-agent?bcId=bc-a9ed7235-830e-4b9f-845f-8bd8f81c487a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a9ed7235-830e-4b9f-845f-8bd8f81c487a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

